### PR TITLE
既存APIの修正

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,5 +1,7 @@
 module Api::V1
   class ArticlesController < BaseApiController
+    before_action :authenticate_user!, only: [:create, :update, :destroy]
+
     def index
       articles = Article.order(updated_at: :desc)
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::BaseApiController < ApplicationController
-  def current_user
-    @current_user ||= User.first
-  end
+  alias_method :current_user, :current_api_v1_user
+  alias_method :authenticate_user!, :authenticate_api_v1_user!
+  alias_method :user_signed_in?, :api_v1_user_signed_in?
 end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -47,13 +47,11 @@ RSpec.describe "Api::V1::Articles", type: :request do
     end
 
     describe "POST /articles" do
-      subject { post(api_v1_articles_path, params: params) }
+      subject { post(api_v1_articles_path, params: params, headers: headers) }
 
       let(:current_user) { create(:user) }
       let(:params) { { article: attributes_for(:article) } }
-
-      # rubocop:disable all
-      before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+      let(:headers) { current_user.create_new_auth_token }
 
       it "記事の作成ができる" do
         expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1)
@@ -65,12 +63,11 @@ RSpec.describe "Api::V1::Articles", type: :request do
     end
 
     describe "PATCH /api/v1/articles/:id" do
-      subject { patch(api_v1_article_path(article.id), params: params) }
+      subject { patch(api_v1_article_path(article.id), params: params, headers: headers) }
 
       let(:params) { { article: attributes_for(:article) } }
       let(:current_user) { create(:user) }
-
-      before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+      let(:headers) { current_user.create_new_auth_token }
 
       context "自分の記事のを更新する時" do
         let(:article) { create(:article, user: current_user) }
@@ -93,12 +90,11 @@ RSpec.describe "Api::V1::Articles", type: :request do
     end
 
     describe "DELETE /api/v1/articles/:id" do
-      subject { delete(api_v1_article_path(article_id)) }
+      subject { delete(api_v1_article_path(article_id), headers: headers) }
 
       let(:current_user) { create(:user) }
       let(:article_id) { article.id }
-      before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
-      # rubocop:enable all
+      let(:headers) { current_user.create_new_auth_token }
 
       context "自分の記事を削除しようとした時" do
         let!(:article) { create(:article, user: current_user) }


### PR DESCRIPTION
## 概要
- articles_controllerにbefore_action authenticateを実装
- alias_method を使いbase_api_controllerの一部を変更
- articles_spec の投稿・更新・削除のテストコードをリファクタリング